### PR TITLE
Fix dragging behavior

### DIFF
--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -6,6 +6,7 @@ import Editor from "../Editor";
 import { Guid } from "guid-typescript";
 import Node from "../../nodes/Node";
 import GraphNode from "./GraphNode";
+import IPosition from "./IPosition";
 
 const GRID_SIZE: number = 10000; // in px
 const GRID_SIZE_HALF: number = 5000; // in px
@@ -22,11 +23,6 @@ interface IGraphState {
 	nodes: Array<Node>;
 }
 
-interface IPosition {
-	x: number;
-	y: number
-}
-
 export default class Graph extends React.Component<IGraphProperties, IGraphState> {
 	private currentZoom: number = 1;
 	private mouseDown: boolean = false;
@@ -38,7 +34,7 @@ export default class Graph extends React.Component<IGraphProperties, IGraphState
 	private yOffset: number = 0;
 
 	private nodeTable: Map<Guid, Node>;
-	private selectedGraphNode?: GraphNode;
+	private selectedGraphNode: GraphNode | null = null;
 
 	constructor(props: IGraphProperties) {
 		super(props);
@@ -63,11 +59,11 @@ export default class Graph extends React.Component<IGraphProperties, IGraphState
 		return GRID_SIZE;
 	}
 
-	public setSelectedGraphNode(node: GraphNode | undefined): void {
+	public setSelectedGraphNode(node: GraphNode | null): void {
 		this.selectedGraphNode = node;
 	}
 
-	public getSelectedGraphNode(): GraphNode | undefined {
+	public getSelectedGraphNode(): GraphNode | null {
 		return this.selectedGraphNode;
 	}
 
@@ -227,7 +223,7 @@ export default class Graph extends React.Component<IGraphProperties, IGraphState
 
 	private onMouseUp(): void {
 		this.mouseDown = false;
-		this.selectedGraphNode = undefined;
+		this.selectedGraphNode = null;
 		document.body.style.cursor = "auto";
 	}
 

--- a/src/components/graph/GraphNode.tsx
+++ b/src/components/graph/GraphNode.tsx
@@ -9,31 +9,48 @@ interface IGraphNodeProperties {
 	node: Node;
 }
 
+interface IPosition {
+	x: number;
+	y: number
+}
+
 const NODE_HEADER_HEIGHT: number = 21;
 
 export default class GraphNode extends React.Component<IGraphNodeProperties> {
-	private mouseDown: boolean = false;
 
-	private onMouseDown(): void {
-		this.props.graph.isMoveable = false;
-		this.mouseDown = true;
-	}
+	private offsetX: number = 0;
+	private offsetY: number = 0;
+	private offsetZoom: number = 0;
 
-	private onMouseUp(): void {
-		this.mouseDown = false;
-		this.props.graph.isMoveable = true;
-	}
-
-	private onMouseMove({ movementX, movementY }: MouseEvent): void {
-		if (!this.mouseDown) return;
+	private onMouseDown(event: React.MouseEvent): void {
 
 		const x = this.props.node.getX(), y = this.props.node.getY()
-		this.props.node.setCoordinates(x + movementX, y + movementY);
-		this.props.graph.updateNodes();
+		const screenPos = this.props.graph.graphToPageCoordinates(x, y);
+		const zoom = this.props.graph.getCurrentZoom();
+		this.offsetX = event.pageX - screenPos.x;
+		this.offsetY = event.pageY - screenPos.y;
+		this.offsetZoom = zoom;
+
+		this.props.graph.setSelectedGraphNode(this);
+		this.props.graph.isMoveable = false;
+	}
+
+	private onMouseMove(event: MouseEvent): void {
+		if (this.props.graph.getSelectedGraphNode() !== this) return;
+
+		this.updatePosition(event);
 	}
 
 	private onClose(): void {
 		this.props.graph.removeNode(this.props.node.getId());
+	}
+
+	public updatePosition(event: MouseEvent): void {
+		const zoom = 1 + (this.props.graph.getCurrentZoom() - this.offsetZoom) / this.offsetZoom;
+		const graphPos = this.props.graph.pageToGraphCoordinates(event.pageX - this.offsetX * zoom, event.pageY - this.offsetY * zoom);
+
+		this.props.node.setCoordinates(graphPos.x, graphPos.y);
+		this.props.graph.updateNodes();
 	}
 
 	public componentDidMount(): void {
@@ -92,7 +109,6 @@ export default class GraphNode extends React.Component<IGraphNodeProperties> {
 						cursor: "move"
 					}}
 					onMouseDown={this.onMouseDown.bind(this)}
-					onMouseUp={this.onMouseUp.bind(this)}
 					className="header">
 					<div>{this.props.node.getName()}</div>
 					<button onClick={this.onClose.bind(this)}>x</button>

--- a/src/components/graph/GraphNode.tsx
+++ b/src/components/graph/GraphNode.tsx
@@ -9,11 +9,6 @@ interface IGraphNodeProperties {
 	node: Node;
 }
 
-interface IPosition {
-	x: number;
-	y: number
-}
-
 const NODE_HEADER_HEIGHT: number = 21;
 
 export default class GraphNode extends React.Component<IGraphNodeProperties> {

--- a/src/components/graph/IPosition.tsx
+++ b/src/components/graph/IPosition.tsx
@@ -1,0 +1,6 @@
+// This file should be renamed and move to a more appropiate folder at some point
+
+export default interface IPosition {
+	x: number;
+	y: number
+}

--- a/src/components/menu/NodeMenuItem.tsx
+++ b/src/components/menu/NodeMenuItem.tsx
@@ -35,7 +35,7 @@ export default class NodeMenuItem extends React.Component<INodeMenuItemPropertie
 		const graph = this.props.editor.graph;
 		if (graph == null) return;
 
-		const { x, y } = node.computeCoordinates(graph, pageX, pageY);
+		const { x, y } = graph.pageToGraphCoordinates(pageX, pageY);
 		node.setCoordinates(x, y);
 		graph.addNode(node);
 	}

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -55,8 +55,8 @@ export default class Node implements INode {
 		const screenHeight: number = window.innerHeight;
 
 		const currentZoom: number = graph.getCurrentZoom();
-		const xOffset: number = graph.getXOffset() / currentZoom - screenWidth / 2 / currentZoom;
-		const yOffset: number = graph.getYOffset() / currentZoom - screenHeight / 2 / currentZoom;
+		const xOffset: number = (graph.getXOffset() - screenWidth / 2) / currentZoom;
+		const yOffset: number = (graph.getYOffset() - screenHeight / 2) / currentZoom;
 		const halfSize: number = graph.getSize() / 2;
 
 		return {

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -1,6 +1,5 @@
 import { Guid } from "guid-typescript";
 import Editor from "../components/Editor";
-import Graph from "../components/graph/Graph";
 
 const DEFAULT_NODE_WIDTH: number = 125;
 
@@ -14,11 +13,6 @@ interface INode {
 	getName(): string;
 	getColor(): string;
 	properties: Map<string, any>;
-}
-
-interface IPosition {
-	x: number;
-	y: number
 }
 
 export default class Node implements INode {
@@ -48,21 +42,6 @@ export default class Node implements INode {
 
 	public get properties(): Map<string, any> {
 		return this._properties;
-	}
-
-	public computeCoordinates(graph: Graph, pageX: number, pageY: number): IPosition {
-		const screenWidth: number = window.innerWidth;
-		const screenHeight: number = window.innerHeight;
-
-		const currentZoom: number = graph.getCurrentZoom();
-		const xOffset: number = (graph.getXOffset() - screenWidth / 2) / currentZoom;
-		const yOffset: number = (graph.getYOffset() - screenHeight / 2) / currentZoom;
-		const halfSize: number = graph.getSize() / 2;
-
-		return {
-			x: halfSize + xOffset + pageX / currentZoom,
-			y: halfSize + yOffset + pageY / currentZoom,
-		};
 	}
 
 	public setCoordinates(x: number, y: number): void {


### PR DESCRIPTION
This pull request fixes the issue where dragging would lose which GraphNode was being dragged.

There is a global variable in Graph called selected GraphNode which is whatever node is being dragged at the moment
This allows the global Graph object to correct the GraphNode position accordingly when the OnWheel and OnMouseDown events are fired